### PR TITLE
Add declined meetings parameter and enforce exclusivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,15 @@ meeting-notes fetch --help
 |--------|-------|-------------|
 | `--days N` | `-d` | Number of days back to search (default: 7) |
 | `--accepted` | | Only fetch meetings you've accepted or are tentative for |
+| `--declined` | | Only fetch meetings you've declined (mutually exclusive with --accepted) |
 | `--gemini-only` | `-g` | Only fetch Gemini notes and transcripts, skip other documents |
 | `--smart-filter` | `-s` | Apply smart content filtering to extract only new content from recurring meetings |
 | `--diff-mode` | | **NEW**: Only save new content compared to previous meetings |
 | `--dry-run` | | Preview what would be fetched without saving files |
 | `--force` | `-f` | Force re-fetch meetings even if already processed |
 | `--week YYYY-WW` | `-w` | Fetch specific week (e.g., 2024-W03) |
+
+**Note**: The `--accepted` and `--declined` options are mutually exclusive - you cannot use both at the same time. If neither is specified, all meetings (regardless of response status) will be fetched.
 
 ### New Diff and Changelog Commands
 
@@ -189,6 +192,9 @@ uv run meeting-notes fetch
 
 # Fetch from last 14 days, only accepted meetings
 uv run meeting-notes fetch --days 14 --accepted
+
+# Fetch from last 7 days, only declined meetings
+uv run meeting-notes fetch --days 7 --declined
 
 # Only fetch Gemini-generated notes and transcripts
 uv run meeting-notes fetch --gemini-only

--- a/meeting_notes_handler/google_meet_fetcher.py
+++ b/meeting_notes_handler/google_meet_fetcher.py
@@ -159,12 +159,13 @@ class GoogleMeetFetcher:
             logger.error(f"Authentication failed: {e}")
             return False
     
-    def fetch_recent_meetings(self, days_back: Optional[int] = None, accepted_only: bool = False, gemini_only: bool = False) -> List[Dict[str, Any]]:
+    def fetch_recent_meetings(self, days_back: Optional[int] = None, accepted_only: bool = False, declined_only: bool = False, gemini_only: bool = False) -> List[Dict[str, Any]]:
         """Fetch recent Google Meet meetings from calendar.
         
         Args:
             days_back: Number of days back to search. Uses config default if not provided.
             accepted_only: If True, only fetch meetings the user has accepted or is tentative.
+            declined_only: If True, only fetch meetings the user has declined.
             gemini_only: If True, only fetch Gemini notes and transcripts.
             
         Returns:
@@ -202,6 +203,10 @@ class GoogleMeetFetcher:
                 if self._is_google_meet_meeting(event):
                     if accepted_only and not self._is_user_attending(event):
                         logger.debug(f"Skipping meeting due to non-accepted status: {event.get('summary')}")
+                        continue
+                    
+                    if declined_only and self._is_user_attending(event):
+                        logger.debug(f"Skipping meeting due to non-declined status: {event.get('summary')}")
                         continue
 
                     meeting_info = self._extract_meeting_info(event, gemini_only)
@@ -699,6 +704,7 @@ class GoogleMeetFetcher:
     def fetch_and_process_all(self, days_back: Optional[int] = None, 
                              dry_run: bool = False,
                              accepted_only: bool = False,
+                             declined_only: bool = False,
                              force_refetch: bool = False,
                              gemini_only: bool = False,
                              smart_filtering: bool = False,
@@ -709,6 +715,7 @@ class GoogleMeetFetcher:
             days_back: Number of days back to search.
             dry_run: If True, don't save files, just return results.
             accepted_only: If True, only fetch meetings the user has accepted.
+            declined_only: If True, only fetch meetings the user has declined.
             force_refetch: If True, reprocess meetings even if already processed.
             gemini_only: If True, only fetch Gemini notes and transcripts.
             smart_filtering: If True, apply smart content filtering for new content only.
@@ -720,7 +727,7 @@ class GoogleMeetFetcher:
         if not self.authenticate():
             return {'success': False, 'error': 'Authentication failed'}
         
-        meetings = self.fetch_recent_meetings(days_back, accepted_only=accepted_only, gemini_only=gemini_only)
+        meetings = self.fetch_recent_meetings(days_back, accepted_only=accepted_only, declined_only=declined_only, gemini_only=gemini_only)
         
         results = {
             'success': True,

--- a/meeting_notes_handler/main.py
+++ b/meeting_notes_handler/main.py
@@ -59,15 +59,21 @@ def cli(ctx, config, log_level, version):
 @click.option('--dry-run', is_flag=True, help='Preview without saving files')
 @click.option('--week', '-w', help='Specific week to fetch (YYYY-WW format)')
 @click.option('--accepted', is_flag=True, default=False, help='Only fetch notes from meetings you accepted or are tentative for.')
+@click.option('--declined', is_flag=True, default=False, help='Only fetch notes from meetings you declined.')
 @click.option('--force', '-f', is_flag=True, default=False, help='Force re-fetch meetings even if already processed')
 @click.option('--gemini-only', '-g', is_flag=True, default=False, help='Only fetch Gemini notes and transcripts, skip other documents')
 @click.option('--smart-filter', '-s', is_flag=True, default=False, help='Apply smart content filtering to extract only new content from recurring meetings')
 @click.option('--diff-mode', is_flag=True, default=False, help='Only save new content compared to previous meetings')
 @click.pass_context
-def fetch(ctx, days, dry_run, week, accepted, force, gemini_only, smart_filter, diff_mode):
+def fetch(ctx, days, dry_run, week, accepted, declined, force, gemini_only, smart_filter, diff_mode):
     """Fetch meeting notes from Google Calendar and Docs."""
     config = ctx.obj['config']
     logger = logging.getLogger(__name__)
+    
+    # Validate mutually exclusive options
+    if accepted and declined:
+        click.echo("❌ Error: --accepted and --declined options are mutually exclusive", err=True)
+        sys.exit(1)
     
     if week:
         click.echo(f"Week-specific fetching not yet implemented: {week}")
@@ -78,6 +84,8 @@ def fetch(ctx, days, dry_run, week, accepted, force, gemini_only, smart_filter, 
         click.echo("📋 DRY RUN - No files will be saved")
     if accepted:
         click.echo("✅ Filtering for accepted meetings only")
+    if declined:
+        click.echo("❌ Filtering for declined meetings only")
     if force:
         click.echo("🔄 FORCE MODE - Will re-fetch already processed meetings")
     if gemini_only:
@@ -102,6 +110,7 @@ def fetch(ctx, days, dry_run, week, accepted, force, gemini_only, smart_filter, 
             days_back=days, 
             dry_run=dry_run, 
             accepted_only=accepted, 
+            declined_only=declined,
             force_refetch=force, 
             gemini_only=gemini_only, 
             smart_filtering=smart_filter,


### PR DESCRIPTION
Add `--declined` option to meeting fetcher, mutually exclusive with `--accepted`, to allow fetching only declined meetings.

---
<a href="https://cursor.com/background-agent?bcId=bc-f790c855-3dea-4a35-bff6-7831917dae78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f790c855-3dea-4a35-bff6-7831917dae78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

